### PR TITLE
Switch to AES-GCM encryption

### DIFF
--- a/encryption.py
+++ b/encryption.py
@@ -1,6 +1,7 @@
 # encryption.py  ─────────────────────────────────────────────
 
 from Cryptodome.Cipher import AES      # pycryptodomex
+from Cryptodome.Random import get_random_bytes
 
 def _pkcs7_pad(data: bytes, block: int = 16) -> bytes:
     pad_len = block - len(data) % block
@@ -17,12 +18,24 @@ def _bits_to_key(key_bits: str) -> bytes:
     return (key + b'\x00'*16)[:16]         # دقیقاً 16 بایت
 
 def encrypt_message_AES(key_bits: str, plaintext: str) -> bytes:
+    """Encrypt plaintext using AES-GCM with a random nonce.
+
+    The returned bytes contain ``nonce || tag || ciphertext`` so that the
+    caller can directly pass the result to :func:`decrypt_message_AES`.
+    """
     key = _bits_to_key(key_bits)
-    cipher = AES.new(key, AES.MODE_ECB)
-    return cipher.encrypt(_pkcs7_pad(plaintext.encode(), 16))
+    nonce = get_random_bytes(12)                 # recommended size for GCM
+    cipher = AES.new(key, AES.MODE_GCM, nonce=nonce)
+    ciphertext, tag = cipher.encrypt_and_digest(plaintext.encode())
+    return nonce + tag + ciphertext
 
 def decrypt_message_AES(key_bits: str, ciphertext: bytes) -> str:
+    """Decrypt data produced by :func:`encrypt_message_AES`. Raises an
+    exception if authentication fails."""
     key = _bits_to_key(key_bits)
-    cipher = AES.new(key, AES.MODE_ECB)
-    plain = cipher.decrypt(ciphertext)
-    return _pkcs7_unpad(plain).decode()
+    nonce = ciphertext[:12]
+    tag = ciphertext[12:28]
+    ct = ciphertext[28:]
+    cipher = AES.new(key, AES.MODE_GCM, nonce=nonce)
+    plain = cipher.decrypt_and_verify(ct, tag)
+    return plain.decode()


### PR DESCRIPTION
## Summary
- replace ECB encryption in `encryption.py` with AES‑GCM
- generate a random nonce and prepend it with the tag and ciphertext

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845f4b7af488320b319930f415baf38