### PR TITLE
Enhance security and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Distributed Quantum Computing with Hybrid Secure Communication
+
+This project demonstrates a simple quantum network using BB84 key exchange,
+AES-GCM encryption, and a multi-node simulation of Grover's algorithm. It
+provides a Tkinter GUI for running demos and visualizing results.
+
+## Installation
+
+1. Install Python 3.10 or later.
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Running
+
+```
+python main.py
+```
+
+The GUI lets you exchange keys, send encrypted messages, and run Grover search.
+
+## Testing
+
+Run the unit tests with:
+
+```
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+qiskit
+qiskit-aer
+pycryptodomex
+matplotlib
+networkx
+pandas
+tk
+pytest

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -1,0 +1,12 @@
+import sys, os
+import pytest
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from encryption import encrypt_message_AES, decrypt_message_AES
+
+
+def test_encrypt_roundtrip():
+    key = '1010101010101010'
+    msg = 'hello world'
+    ct = encrypt_message_AES(key, msg)
+    pt = decrypt_message_AES(key, ct)
+    assert pt == msg

--- a/tests/test_grover.py
+++ b/tests/test_grover.py
@@ -1,0 +1,14 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from channels import QuantumChannel
+from nodes import QuantumNode
+from grover import distributed_grover_search
+
+
+def test_distributed_grover():
+    nodes = [QuantumNode('A', 2), QuantumNode('B', 2)]
+    qch = QuantumChannel()
+    target = '11'
+    best, counts = distributed_grover_search(nodes, target, qchannel=qch)
+    assert best == target
+    assert sum(counts.values()) > 0

--- a/tests/test_qkd.py
+++ b/tests/test_qkd.py
@@ -1,0 +1,15 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from channels import QuantumChannel, ClassicalChannel
+from nodes import QuantumNode
+from qkd import bb84_key_exchange
+
+
+def test_bb84_key_exchange():
+    alice = QuantumNode('Alice', 1)
+    bob = QuantumNode('Bob', 1)
+    qch = QuantumChannel()
+    cch = ClassicalChannel()
+    key = bb84_key_exchange(alice, bob, 16, qch, cch)
+    assert key is not None
+    assert len(key) == 16


### PR DESCRIPTION
## Summary
- implement AES-GCM for authenticated encryption
- simulate Grover search across nodes with delays
- provide README and requirements list
- add unit tests for encryption, QKD and Grover

## Testing
- `pytest -q` *(fails: No module named 'Cryptodome', 'qiskit')*

------
https://chatgpt.com/codex/tasks/task_e_6845f2974838832092b6cd47669fbb22